### PR TITLE
fix: add base method for generating tags block w/ map fn from terraform-generator

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ const config = defineConfig(
                 project: "./tsconfig.json",
             },
         },
-        files: ["**/*.ts"],
+        files: ["src/**/*.ts"],
         ignores: ["**/*.test.ts"],
         plugins: {
             "@stylistic": stylistic,

--- a/src/utilities/generators/aws-generator.test.ts
+++ b/src/utilities/generators/aws-generator.test.ts
@@ -19,6 +19,14 @@ describe("AwsGenerator", () => {
 
             expect(AWS_INSTANCE_TYPES).toContain(instanceType);
         });
+
+        it("adds tags block", () => {
+            const terraform = new AwsGenerator({ tags: { foo: "bar" } })
+                .addComputeInstance()
+                .toString();
+
+            expect(terraform).toContain("tags = {");
+        });
     });
 
     describe("addLambdaFunction", () => {
@@ -30,6 +38,14 @@ describe("AwsGenerator", () => {
             const runtime = getLambdaRuntime(terraform);
 
             expect(AWS_LAMBDA_RUNTIMES).toContainEqual(runtime);
+        });
+
+        it("adds tags block", () => {
+            const terraform = new AwsGenerator({ tags: { foo: "bar" } })
+                .addLambdaFunction()
+                .toString();
+
+            expect(terraform).toContain("tags = {");
         });
     });
 });

--- a/src/utilities/generators/aws-generator.ts
+++ b/src/utilities/generators/aws-generator.ts
@@ -45,7 +45,7 @@ class AwsGenerator extends ProviderGenerator {
             ami,
             instance_type: instanceType,
             ...rootBlockDevice,
-            tags: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;
@@ -72,7 +72,7 @@ class AwsGenerator extends ProviderGenerator {
             function_name: functionName,
             memory_size: memorySize,
             role,
-            tags: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;

--- a/src/utilities/generators/azure-generator.test.ts
+++ b/src/utilities/generators/azure-generator.test.ts
@@ -19,6 +19,14 @@ describe("AzureGenerator", () => {
 
             expect(AZURE_INSTANCE_TYPES).toContain(machineType);
         });
+
+        it("adds tags block", () => {
+            const terraform = new AzureGenerator({ tags: { foo: "bar" } })
+                .addComputeInstance()
+                .toString();
+
+            expect(terraform).toContain("tags = {");
+        });
     });
 
     describe("addLambdaFunction", () => {
@@ -41,6 +49,14 @@ describe("AzureGenerator", () => {
             const runtime = getLambdaRuntime(terraform);
 
             expect(AZURE_LAMBDA_RUNTIMES).toContainEqual(runtime);
+        });
+
+        it("adds tags block", () => {
+            const terraform = new AzureGenerator({ tags: { foo: "bar" } })
+                .addLambdaFunction()
+                .toString();
+
+            expect(terraform).toContain("tags = {");
         });
     });
 });

--- a/src/utilities/generators/azure-generator.ts
+++ b/src/utilities/generators/azure-generator.ts
@@ -26,7 +26,7 @@ class AzureGenerator extends ProviderGenerator {
 
         this.tfg.resource(AzureResourceType.ComputeInstance, name, {
             size: instanceType,
-            tags: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;
@@ -47,7 +47,7 @@ class AzureGenerator extends ProviderGenerator {
             ...runtime,
             name,
             instance_memory_in_mb: instanceMemoryInMb,
-            tags: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;

--- a/src/utilities/generators/gcp-generator.test.ts
+++ b/src/utilities/generators/gcp-generator.test.ts
@@ -19,6 +19,14 @@ describe("GcpGenerator", () => {
 
             expect(GCP_INSTANCE_TYPES).toContain(machineType);
         });
+
+        it("adds tags block", () => {
+            const terraform = new GcpGenerator({ tags: { foo: "bar" } })
+                .addComputeInstance()
+                .toString();
+
+            expect(terraform).toContain("labels = {");
+        });
     });
 
     describe("addLambdaFunction", () => {
@@ -30,6 +38,14 @@ describe("GcpGenerator", () => {
             const runtime = getLambdaRuntime(terraform);
 
             expect(GCP_LAMBDA_RUNTIMES).toContainEqual(runtime);
+        });
+
+        it("adds tags block", () => {
+            const terraform = new GcpGenerator({ tags: { foo: "bar" } })
+                .addLambdaFunction()
+                .toString();
+
+            expect(terraform).toContain("labels = {");
         });
     });
 });

--- a/src/utilities/generators/gcp-generator.ts
+++ b/src/utilities/generators/gcp-generator.ts
@@ -11,6 +11,7 @@ import {
     randomMemorableSlug,
     randomMemorySize,
 } from "./generator-utils.js";
+import type { ProviderGeneratorOptions } from "./provider-generator.js";
 import { ProviderGenerator } from "./provider-generator.js";
 
 const GcpResourceType = {
@@ -19,6 +20,11 @@ const GcpResourceType = {
 } as const;
 
 class GcpGenerator extends ProviderGenerator {
+    constructor(options?: ProviderGeneratorOptions) {
+        super(options);
+        this.tagKey = "labels";
+    }
+
     public addProvider(): void {
         this.tfg.provider("google", { region: this.region });
     }
@@ -39,7 +45,7 @@ class GcpGenerator extends ProviderGenerator {
             zone: this.region,
             machine_type: machineType,
             ...guestAccelerator,
-            labels: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;
@@ -59,7 +65,7 @@ class GcpGenerator extends ProviderGenerator {
             runtime,
             name,
             available_memory_mb: availableMemoryMb,
-            labels: this.getTags(),
+            ...this.getTagsBlock(),
         });
 
         return this;

--- a/src/utilities/generators/provider-generator.ts
+++ b/src/utilities/generators/provider-generator.ts
@@ -1,4 +1,5 @@
-import { TerraformGenerator } from "terraform-generator";
+import type { Map } from "terraform-generator";
+import { map, TerraformGenerator } from "terraform-generator";
 import type { ResourceType } from "../../enums/resource-types.js";
 import { ResourceTypes } from "../../enums/resource-types.js";
 import {
@@ -33,12 +34,18 @@ abstract class ProviderGenerator {
     public readonly tfg: TerraformGenerator;
     public readonly region: string;
     public readonly tags?: ProviderGeneratorTags;
+    /**
+     * Provider-specific key for `tags` objects.
+     * @default tags
+     */
+    public tagKey: string;
 
     public constructor(options?: ProviderGeneratorOptions) {
         this.tfg = new TerraformGenerator();
         this.region = this.randomRegion();
         this.addProvider();
         this.tags = options?.tags;
+        this.tagKey = "tags";
     }
 
     /**
@@ -75,6 +82,20 @@ abstract class ProviderGenerator {
         }
 
         return this.tags;
+    }
+
+    /**
+     * Constructs the tag object to spread onto a resource, where the key is provider specific
+     * (usually `tags` or `labels`) and the value is a `Map` constructed from the object returned from
+     * `getTags`.
+     */
+    public getTagsBlock(): Record<string, Map> | undefined {
+        const tags = this.getTags();
+        if (tags === undefined) {
+            return undefined;
+        }
+
+        return { [this.tagKey]: map(tags) };
     }
 
     public toString(): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        exclude: ["node_modules", "dist"],
+    },
+});


### PR DESCRIPTION
fixes #17 - the value needs to be wrapped in the `map` fn